### PR TITLE
Fix bug where spring TestExecutionListener afterTestClass hook is not called

### DIFF
--- a/src/main/java/org/easetech/easytest/runner/SpringTestRunner.java
+++ b/src/main/java/org/easetech/easytest/runner/SpringTestRunner.java
@@ -24,8 +24,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.Factory;
+
 import org.easetech.easytest.annotation.Converters;
 import org.easetech.easytest.annotation.DataLoader;
 import org.easetech.easytest.annotation.Duration;
@@ -63,6 +65,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.AopConfigException;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks;
 
 /**
  * A {@link SpringJUnit4ClassRunner} Runner extension that adds support of input parameters as part of the {@link Test}
@@ -426,7 +429,7 @@ public class SpringTestRunner extends SpringJUnit4ClassRunner {
                 throw new RuntimeException(e);
             }
         }
-        return new InternalParameterizedStatement((EasyFrameworkMethod) method, getTestClass(), testInstance);
+        return new InternalParameterizedStatement(null, (EasyFrameworkMethod) method, getTestClass(), testInstance);
     }
 
     private void handleDuration(FrameworkMethod method, Object testInstance) throws IllegalArgumentException,
@@ -565,7 +568,7 @@ public class SpringTestRunner extends SpringJUnit4ClassRunner {
         }
         RunAftersWithOutputData runAftersWithOutputData = new RunAftersWithOutputData(statement, afters, null,
             testInfoList, writableData, testReportContainer);
-        return runAftersWithOutputData;
+        return new RunAfterTestClassCallbacks(runAftersWithOutputData, getTestContextManager());
     }
 
     /**

--- a/src/test/java/org/easetech/easytest/listener/ListenerTest.java
+++ b/src/test/java/org/easetech/easytest/listener/ListenerTest.java
@@ -1,0 +1,54 @@
+package org.easetech.easytest.listener;
+
+import org.easetech.easytest.runner.SpringTestRunner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+@RunWith(SpringTestRunner.class)
+@TestExecutionListeners(listeners = {ListenerTest.class, 
+		DependencyInjectionTestExecutionListener.class})
+@ContextConfiguration("/test-context.xml")
+public class ListenerTest implements TestExecutionListener {
+
+	@BeforeClass
+	public static void before() {
+		System.out.println("BeforeClass called");
+	}
+	
+	@Test
+	public void myTest() {
+		System.out.println("Test executed");
+	}
+	
+	@AfterClass
+	public static void after() {
+		System.out.println("AfterClass called");
+	}
+
+	public void beforeTestClass(TestContext testContext) throws Exception {
+		System.out.println("Listener before test class called");
+	}
+
+	public void prepareTestInstance(TestContext testContext) throws Exception {
+		System.out.println("Prepare test instance called");
+	}
+
+	public void beforeTestMethod(TestContext testContext) throws Exception {
+		System.out.println("Listener before test method called");
+	}
+
+	public void afterTestMethod(TestContext testContext) throws Exception {
+		System.out.println("Listener after test method called");
+	}
+
+	public void afterTestClass(TestContext testContext) throws Exception {
+		System.out.println("Listener after test class called");
+	}
+}

--- a/src/test/resources/test-context.xml
+++ b/src/test/resources/test-context.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans 
+       http://www.springframework.org/schema/beans/spring-beans-3.2.xsd 
+       http://www.springframework.org/schema/context 
+       http://www.springframework.org/schema/context/spring-context-3.2.xsd">
+    <context:component-scan base-package="org.easetech" />
+</beans>


### PR DESCRIPTION
Along with a fix, I added ListenerTest class depicting minimal setup required to make the bug occure. The correct implementation should call all the methods from ListenerTest once. The buggy one didn't call 'afterTestClass'
Apart from fixing described bug, I fixed strange compilation error. When I cloned the master and run mvn install, I got compilation error in SpringTestRunner line 432. To fix it I just passed null original Statement into InternalParameterizedStatement constructor. All tests passed so should be fine.
Please review if my changes make sense. 

Thanks,
Bart
